### PR TITLE
Corrected errors in input+output plane coordinate systems and added lens example

### DIFF
--- a/examples/lens_point_spread_function.py
+++ b/examples/lens_point_spread_function.py
@@ -1,0 +1,45 @@
+import diffractsim
+from diffractsim import MonochromaticField, nm
+print(diffractsim.__file__)
+import pylab as pl
+# Change the string to "CUDA" to use GPU acceleration
+diffractsim.set_backend("CPU")
+
+# PARAMETERS
+wlen = 1000 * nm
+Nx = Ny = 2048
+dx = dy = 400 * nm
+focal_distance = 10 * Nx * dx  # 10 times lens diameter
+
+# SETUP AND PROPAGATION
+F = MonochromaticField(
+    wavelength=wlen,
+    extent_x=Nx * dx,
+    extent_y=Nx * dx,
+    Nx=Nx,
+    Ny=Ny)
+
+F.add_lens(f=focal_distance)
+F.propagate(focal_distance)
+
+# POST PROCESSING
+# Find indices closest to (0,0)
+idx_x = pl.argmin(abs(F.x-0))
+idx_y = pl.argmin(abs(F.y-0))
+# Plot PSF cross-sectionis
+pl.plot(F.x * 1e6, F.I[idx_x, :], label='PSF in x', lw=2)
+pl.plot(F.y * 1e6, F.I[:, idx_y], label='PSF in y', lw=2)
+pl.xlabel('x (um)')
+pl.xlim(-30, 30)
+pl.legend()
+pl.show()
+
+# Image plot of PSF
+extent = 1e6 * pl.array([F.x.min(), F.x.max(), F.y.min(), F.y.max()])
+pl.imshow(F.I, extent=extent)
+pl.xlim(-30, 30)
+pl.ylim(-30, 30)
+pl.xlabel('x (um)')
+pl.ylabel('y (um)')
+pl.colorbar()
+pl.show()


### PR DESCRIPTION
There is a mistake in the coordinate system definitions of the current version which means that for example a lens does not focus exactly on the optical axis. If you try and run the supplied example in an old version of the code you would get:


![old_image](https://user-images.githubusercontent.com/25103340/140076888-8e0b6019-f7ef-4737-91c0-eb4c2bbe8517.png)
![old_PSF](https://user-images.githubusercontent.com/25103340/140076895-85f5e45b-5de8-472c-b7ed-ef4b779c4369.png)

And with the new version you would instead get the following on-axis responses:

![new_image](https://user-images.githubusercontent.com/25103340/140077045-60ba79f5-d263-4598-b833-605b3236b0fe.png)
![new_PSF](https://user-images.githubusercontent.com/25103340/140077047-3d305ad9-fea6-4627-8f8e-06db83e29595.png)


P.S. I have also updated the calculation of `kz` in order to include non-propagating modes. If not, the supplied example will fail

P.P.S. Changes only made to the monochromatic simulator

