### PR TITLE
Vectorial angular spectrum propagation with Maxwell consistency

### DIFF
--- a/diffractsim/fields/vector_field.py
+++ b/diffractsim/fields/vector_field.py
@@ -1,0 +1,28 @@
+"""
+VectorField representation for electromagnetic simulations.
+
+This module introduces a vectorial field abstraction without
+modifying or interfering with existing scalar-field logic.
+"""
+
+import numpy as np
+
+class VectorField:
+    """
+    Represents a monochromatic electromagnetic field using
+    transverse electric field components.
+    """
+
+    def __init__(self, Ex, Ey, wavelength, x, y):
+        self.Ex = np.asarray(Ex, dtype=complex)
+        self.Ey = np.asarray(Ey, dtype=complex)
+        self.wavelength = wavelength
+        self.x = x
+        self.y = y
+
+        if self.Ex.shape != self.Ey.shape:
+            raise ValueError("Ex and Ey must have identical shapes")
+
+    @property
+    def shape(self):
+        return self.Ex.shape

--- a/diffractsim/propagation/vector_angular_spectrum.py
+++ b/diffractsim/propagation/vector_angular_spectrum.py
@@ -54,22 +54,41 @@ def propagate_vector_angular_spectrum(field, z):
     # resulting in decaying exponentials exp(-|kz|z) which is physically correct.
     kz = np.sqrt(kz_sq.astype(complex))
 
+    # 2. Evanescent Decay Sign Enforcement: Enforce Im(kz) >= 0
+    # This ensures that evanescent waves decay (exp(-|Im(kz)|*z)) rather than grow.
+    # While np.sqrt usually handles this, numerical noise can flip the sign.
+    kz = np.where(np.imag(kz) < 0, np.conj(kz), kz)
+
     # Fourier transform of transverse components
     Ex_k = np.fft.fft2(Ex)
     Ey_k = np.fft.fft2(Ey)
 
-    # Compute Ez in Fourier domain to enforce div(E) = 0 -> k . E = 0
-    # kz * Ez_k = -(kx * Ex_k + ky * Ey_k)
-    # Handle singularity at kz=0 by setting Ez_k=0 (purely transverse propagation)
+    # 1. Ez Reconstruction Order: Compute Ez BEFORE propagation
+    # We must construct Ez in the source plane and THEN propagate it 
+    # using the same transfer function as Ex and Ey.
+    # div(E) = 0 -> kx*Ex + ky*Ey + kz*Ez = 0
     with np.errstate(divide='ignore', invalid='ignore'):
         Ez_k = -(KX * Ex_k + KY * Ey_k) / kz
     
+    # Handle singularity at kz=0 (avoid NaNs)
     Ez_k[np.abs(kz) < 1e-9] = 0.0
+
+    # 3. On-Axis Symmetry Enforcement: Ez must be 0 at DC (kx=ky=0)
+    # Physically, for a symmetric beam, the longitudinal component is zero on-axis.
+    # Numerical noise or division by small kz can perturb this.
+    # We identify the DC component where KX=0 and KY=0.
+    dc_mask = (KX == 0) & (KY == 0)
+    Ez_k[dc_mask] = 0.0
+
+    # Note: Ez may still exhibit small non-zero values on-axis in the spatial domain
+    # due to finite grid discretization and the asymmetry of the FFT Nyquist component.
+    # This is a numerical artifact that decreases with higher resolution and does
+    # not violate physical consistency.
 
     # Optical transfer function (propagator)
     H = np.exp(1j * kz * z)
 
-    # Propagate components
+    # Propagate ALL components with the same kernel
     Ex_k_propagated = Ex_k * H
     Ey_k_propagated = Ey_k * H
     Ez_k_propagated = Ez_k * H

--- a/diffractsim/propagation/vector_angular_spectrum.py
+++ b/diffractsim/propagation/vector_angular_spectrum.py
@@ -1,0 +1,89 @@
+"""
+Vectorial Angular Spectrum Method.
+
+Implements Maxwell-consistent propagation for vector fields.
+"""
+
+import numpy as np
+
+def propagate_vector_angular_spectrum(field, z):
+    """
+    Propagate a VectorField using vectorial angular spectrum method.
+
+    Parameters
+    ----------
+    field : VectorField
+        Input electromagnetic field
+    z : float
+        Propagation distance
+
+    Returns
+    -------
+    VectorField
+        Propagated field
+    """
+    # Retrieve field parameters
+    Ex = field.Ex
+    Ey = field.Ey
+    wavelength = field.wavelength
+    x = field.x
+    y = field.y
+
+    # Grid parameters
+    nx = len(x)
+    ny = len(y)
+    dx = x[1] - x[0]
+    dy = y[1] - y[0]
+
+    # Compute spatial frequencies (kx, ky)
+    # numpy.fft.fftfreq returns frequencies in cycles/unit_distance
+    fx = np.fft.fftfreq(nx, d=dx)
+    fy = np.fft.fftfreq(ny, d=dy)
+    
+    # Meshgrid for frequencies matching the field shape (ny, nx)
+    # Default meshgrid indexing='xy' -> KX varies along axis 1, KY along axis 0
+    KX, KY = np.meshgrid(2 * np.pi * fx, 2 * np.pi * fy)
+
+    # Compute kz component of the wave vector
+    # kz = sqrt(k^2 - kx^2 - ky^2)
+    k = 2 * np.pi / wavelength
+    kz_sq = k**2 - KX**2 - KY**2
+    
+    # Handle evanescent waves (kz_sq < 0) safely
+    # numpy.sqrt on complex array returns 1j*sqrt(abs(val)) for negative real inputs,
+    # resulting in decaying exponentials exp(-|kz|z) which is physically correct.
+    kz = np.sqrt(kz_sq.astype(complex))
+
+    # Fourier transform of transverse components
+    Ex_k = np.fft.fft2(Ex)
+    Ey_k = np.fft.fft2(Ey)
+
+    # Compute Ez in Fourier domain to enforce div(E) = 0 -> k . E = 0
+    # kz * Ez_k = -(kx * Ex_k + ky * Ey_k)
+    # Handle singularity at kz=0 by setting Ez_k=0 (purely transverse propagation)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        Ez_k = -(KX * Ex_k + KY * Ey_k) / kz
+    
+    Ez_k[np.abs(kz) < 1e-9] = 0.0
+
+    # Optical transfer function (propagator)
+    H = np.exp(1j * kz * z)
+
+    # Propagate components
+    Ex_k_propagated = Ex_k * H
+    Ey_k_propagated = Ey_k * H
+    Ez_k_propagated = Ez_k * H
+
+    # Inverse Fourier transform
+    Ex_propagated = np.fft.ifft2(Ex_k_propagated)
+    Ey_propagated = np.fft.ifft2(Ey_k_propagated)
+    Ez_propagated = np.fft.ifft2(Ez_k_propagated)
+
+    # Return new VectorField with propagated components
+    # We use type(field) to preserve subclassing if any
+    new_field = type(field)(Ex_propagated, Ey_propagated, wavelength, x, y)
+    
+    # Attach computed Ez component (not part of standard VectorField init)
+    new_field.Ez = Ez_propagated
+    
+    return new_field

--- a/tests/vectorial/test_vector_field.py
+++ b/tests/vectorial/test_vector_field.py
@@ -1,0 +1,16 @@
+import numpy as np
+from diffractsim.fields.vector_field import VectorField
+
+def test_vector_field_initialization():
+    Ex = np.ones((32, 32), dtype=complex)
+    Ey = np.zeros((32, 32), dtype=complex)
+
+    field = VectorField(
+        Ex=Ex,
+        Ey=Ey,
+        wavelength=500e-9,
+        x=np.linspace(-1,1,32),
+        y=np.linspace(-1,1,32)
+    )
+
+    assert field.Ex.shape == field.Ey.shape

--- a/tests/vectorial/test_vector_propagation_impl.py
+++ b/tests/vectorial/test_vector_propagation_impl.py
@@ -1,0 +1,83 @@
+import unittest
+import numpy as np
+from diffractsim.fields.vector_field import VectorField
+from diffractsim.propagation.vector_angular_spectrum import propagate_vector_angular_spectrum
+
+class TestVectorPropagation(unittest.TestCase):
+
+    def test_vector_propagation_runs(self):
+        """Verify that propagation runs without raising NotImplementedError."""
+        Ex = np.zeros((32, 32), dtype=complex)
+        Ey = np.zeros((32, 32), dtype=complex)
+        
+        # Simple Gaussian
+        x = np.linspace(-10e-6, 10e-6, 32)
+        y = np.linspace(-10e-6, 10e-6, 32)
+        XX, YY = np.meshgrid(x, y)
+        Ex = np.exp(-(XX**2 + YY**2)/(2e-6)**2).astype(complex)
+
+        field = VectorField(
+            Ex=Ex,
+            Ey=Ey,
+            wavelength=500e-9,
+            x=x,
+            y=y
+        )
+
+        # Should not raise
+        new_field = propagate_vector_angular_spectrum(field, 100e-6)
+        
+        self.assertIsInstance(new_field, VectorField)
+        self.assertTrue(hasattr(new_field, 'Ez'))
+        self.assertEqual(new_field.Ex.shape, Ex.shape)
+        self.assertEqual(new_field.Ez.shape, Ex.shape)
+
+    def test_divergence_free(self):
+        """Verify that the propagated field satisfies div(E) = 0 in k-space."""
+        N = 64
+        L = 20e-6
+        wavelength = 500e-9
+        x = np.linspace(-L/2, L/2, N)
+        y = np.linspace(-L/2, L/2, N)
+        dx = x[1] - x[0]
+        dy = y[1] - y[0]
+        
+        # Create a random field to test robustness
+        np.random.seed(42)
+        Ex = np.random.randn(N, N) + 1j * np.random.randn(N, N)
+        Ey = np.random.randn(N, N) + 1j * np.random.randn(N, N)
+        
+        # Band-limit
+        mask_freq = np.abs(np.fft.fftfreq(N))[:, None] < 0.2
+        Ex = np.fft.ifft2(np.fft.fft2(Ex) * mask_freq).copy()
+        Ey = np.fft.ifft2(np.fft.fft2(Ey) * mask_freq).copy()
+
+        field = VectorField(Ex, Ey, wavelength, x, y)
+        
+        # Propagate
+        z = 10e-6
+        new_field = propagate_vector_angular_spectrum(field, z)
+        
+        # Check divergence in k-space
+        fx = np.fft.fftfreq(N, dx)
+        fy = np.fft.fftfreq(N, dy)
+        KX, KY = np.meshgrid(2 * np.pi * fx, 2 * np.pi * fy)
+        
+        k = 2 * np.pi / wavelength
+        kz = np.sqrt((k**2 - KX**2 - KY**2).astype(complex))
+        
+        Ex_k = np.fft.fft2(new_field.Ex)
+        Ey_k = np.fft.fft2(new_field.Ey)
+        Ez_k = np.fft.fft2(new_field.Ez)
+        
+        div_k = KX * Ex_k + KY * Ey_k + kz * Ez_k
+        
+        mask = np.abs(kz) > 1e-5
+        if np.any(mask):
+            max_div = np.max(np.abs(div_k[mask]))
+            field_mag = np.max(np.abs(Ex_k))
+            # Relative divergence should be small
+            self.assertLess(max_div / (field_mag + 1e-15), 1e-7)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements a vectorial angular spectrum propagation method that is
consistent with Maxwell’s equations. 
The goal here is to address the core physics limitation discussed in Issue #69:
moving from purely scalar propagation to a vectorial formulation where the
electromagnetic field satisfies the transversality condition (∇·E = 0).

What this PR does:
- Implements vectorial angular spectrum propagation in Fourier space
- Reconstructs the longitudinal field component (Ez) from the transverse
  components (Ex, Ey) to enforce ∇·E = 0
- Uses a single propagation kernel for all field components
- Handles evanescent modes correctly
- Preserves all existing scalar behavior without modification
- Adds tests to validate divergence-free propagation and numerical stability

What this PR intentionally does not do:
- It does not introduce polarization optics (Jones/Stokes, polarizers,
  waveplates)
- It does not modify MonochromaticField or other high-level APIs

Those higher-level features can be built on top of this propagation engine in
follow-up work if desired.

---

Bounty: Algora – Vectorial EM field model

/claim #69