### PR TITLE
feat: add vectorial electric field model with polarization support

### DIFF
--- a/diffractsim/__init__.py
+++ b/diffractsim/__init__.py
@@ -5,6 +5,7 @@ from .util.image_handling import load_image_as_function
 from .util.file_handling import load_file_as_function, load_phase_as_function
 from .polychromatic_simulator import PolychromaticField
 from .monochromatic_simulator import MonochromaticField
+from .vectorial_simulator import VectorialField
 from . import colour_functions as cf
 from .polynomials import zernike_polynomial
 from .holography import FourierPhaseRetrieval, CustomPhaseRetrieval, RotationalPhaseDesign

--- a/diffractsim/diffractive_elements/__init__.py
+++ b/diffractsim/diffractive_elements/__init__.py
@@ -12,3 +12,6 @@ from .aperture_from_image import ApertureFromImage
 from .aperture_from_function import ApertureFromFunction
 
 from .SLM import SLM
+
+from .linear_polarizer import LinearPolarizer
+from .waveplate import Waveplate, HalfWavePlate, QuarterWavePlate

--- a/diffractsim/diffractive_elements/linear_polarizer.py
+++ b/diffractsim/diffractive_elements/linear_polarizer.py
@@ -1,0 +1,30 @@
+import numpy as np
+from ..util.backend_functions import backend as bd
+from .diffractive_element import DOE
+
+class LinearPolarizer(DOE):
+    def __init__(self, angle):
+        """
+        Creates a linear polarizer at a given angle (in degrees)
+        """
+        self.angle = angle
+        self.theta = np.radians(angle)
+
+    def apply_to_vectorial_field(self, field):
+        """
+        Applies the Jones matrix of a linear polarizer to the vectorial field
+        """
+        c = bd.cos(self.theta)
+        s = bd.sin(self.theta)
+        
+        Ex_new = (c**2) * field.Ex + (s*c) * field.Ey
+        Ey_new = (s*c) * field.Ex + (s**2) * field.Ey
+        
+        field.Ex = Ex_new
+        field.Ey = Ey_new
+        field.Ez = bd.zeros_like(field.Ez) # Polarizer is usually a planar element
+
+    def get_transmittance(self, xx, yy, λ):
+        # By default, a polarizer doesn't change the amplitude of a scalar field 
+        # (or it could be argued it should reduce it by 50%, but scalar fields don't have polarization info)
+        return bd.ones_like(xx)

--- a/diffractsim/diffractive_elements/waveplate.py
+++ b/diffractsim/diffractive_elements/waveplate.py
@@ -1,0 +1,47 @@
+import numpy as np
+from ..util.backend_functions import backend as bd
+from .diffractive_element import DOE
+
+class Waveplate(DOE):
+    def __init__(self, phase_delay, fast_axis_angle):
+        """
+        Creates a waveplate with a given phase delay (in radians) and fast axis angle (in degrees)
+        
+        Parameters
+        ----------
+        phase_delay: Phase difference between the fast and slow axes (e.g., pi/2 for QWP, pi for HWP)
+        fast_axis_angle: Angle of the fast axis relative to the x-axis (in degrees)
+        """
+        self.phase_delay = phase_delay
+        self.theta = np.radians(fast_axis_angle)
+
+    def apply_to_vectorial_field(self, field):
+        """
+        Applies the Jones matrix of a waveplate to the vectorial field
+        """
+        c = bd.cos(self.theta)
+        s = bd.sin(self.theta)
+        phi = self.phase_delay
+        
+        # Jones Matrix for a waveplate
+        J11 = bd.exp(1j * phi/2) * c**2 + bd.exp(-1j * phi/2) * s**2
+        J12 = (bd.exp(1j * phi/2) - bd.exp(-1j * phi/2)) * s * c
+        J21 = J12
+        J22 = bd.exp(1j * phi/2) * s**2 + bd.exp(-1j * phi/2) * c**2
+        
+        Ex_new = J11 * field.Ex + J12 * field.Ey
+        Ey_new = J21 * field.Ex + J22 * field.Ey
+        
+        field.Ex = Ex_new
+        field.Ey = Ey_new
+
+    def get_transmittance(self, xx, yy, λ):
+        return bd.ones_like(xx)
+
+class HalfWavePlate(Waveplate):
+    def __init__(self, fast_axis_angle):
+        super().__init__(np.pi, fast_axis_angle)
+
+class QuarterWavePlate(Waveplate):
+    def __init__(self, fast_axis_angle):
+        super().__init__(np.pi/2, fast_axis_angle)

--- a/diffractsim/vectorial_simulator.py
+++ b/diffractsim/vectorial_simulator.py
@@ -1,0 +1,143 @@
+from . import colour_functions as cf
+import matplotlib.pyplot as plt
+import time
+import progressbar
+from .util.constants import *
+from .propagation_methods.angular_spectrum_method import angular_spectrum_method
+
+import numpy as np
+from .util.backend_functions import backend as bd
+
+"""
+Vectorial Electric Field Model
+"""
+
+class VectorialField:
+    def __init__(self, wavelength, extent_x, extent_y, Nx, Ny, intensity=0.1 * W / (m**2), pol_state=[1, 0]):
+        """
+        Initializes the vectorial field.
+
+        Parameters
+        ----------
+        wavelength: wavelength of the plane wave
+        extent_x: length of the rectangular grid 
+        extent_y: height of the rectangular grid 
+        Nx: horizontal dimension of the grid 
+        Ny: vertical dimension of the grid 
+        intensity: total intensity of the field
+        pol_state: list [Ex_rel, Ey_rel] representing the relative polarization state
+        """
+        global bd
+        from .util.backend_functions import backend as bd
+        
+        self.extent_x = extent_x
+        self.extent_y = extent_y
+
+        self.dx = extent_x/Nx
+        self.dy = extent_y/Ny
+
+        self.x = self.dx*(bd.arange(Nx)-Nx//2)
+        self.y = self.dy*(bd.arange(Ny)-Ny//2)
+        self.xx, self.yy = bd.meshgrid(self.x, self.y)
+
+        self.Nx = Nx
+        self.Ny = Ny
+        self.λ = wavelength
+        self.z = 0
+        self.cs = cf.ColourSystem(clip_method = 0)
+        
+        # Normalize polarization state
+        pol_norm = np.sqrt(np.abs(pol_state[0])**2 + np.abs(pol_state[1])**2)
+        ex = pol_state[0] / pol_norm
+        ey = pol_state[1] / pol_norm
+        
+        amplitude = bd.sqrt(intensity)
+        self.Ex = bd.ones((self.Ny, self.Nx), dtype=complex) * amplitude * ex
+        self.Ey = bd.ones((self.Ny, self.Nx), dtype=complex) * amplitude * ey
+        self.Ez = bd.zeros((self.Ny, self.Nx), dtype=complex)
+
+    def add(self, optical_element):
+        """
+        Interaction with an optical element.
+        """
+        if hasattr(optical_element, 'apply_to_vectorial_field'):
+            optical_element.apply_to_vectorial_field(self)
+        else:
+            # Assume scalar element, apply to each component independently
+            self.Ex = optical_element.get_E(self.Ex, self.xx, self.yy, self.λ)
+            self.Ey = optical_element.get_E(self.Ey, self.xx, self.yy, self.λ)
+            self.Ez = optical_element.get_E(self.Ez, self.xx, self.yy, self.λ)
+
+    def propagate(self, z):
+        """
+        Propagate the vectorial field a distance z using the Angular Spectrum Method.
+        """
+        self.z += z
+        
+        # Fourier transform of Ex and Ey
+        tilde_Ex0 = bd.fft.fftshift(bd.fft.fft2(self.Ex))
+        tilde_Ey0 = bd.fft.fftshift(bd.fft.fft2(self.Ey))
+
+        fx = bd.fft.fftshift(bd.fft.fftfreq(self.Nx, d=self.dx))
+        fy = bd.fft.fftshift(bd.fft.fftfreq(self.Ny, d=self.dy))
+        fxx, fyy = bd.meshgrid(fx, fy)
+
+        # k_z calculation
+        k = 2 * bd.pi / self.λ
+        kx = 2 * bd.pi * fxx
+        ky = 2 * bd.pi * fyy
+        
+        # Calculate kz, handling evanescent waves
+        k_sq = k**2 - kx**2 - ky**2
+        kz = bd.sqrt(bd.abs(k_sq))
+        kz = bd.where(k_sq >= 0, kz, 1j * kz)
+
+        # Propagation transfer function
+        H = bd.exp(1j * kz * z)
+        
+        # Propagated angular spectrum for Ex and Ey
+        tilde_Ex = tilde_Ex0 * H
+        tilde_Ey = tilde_Ey0 * H
+        
+        # Calculate tilde_Ez from Gauss's Law: kx*Ex + ky*Ey + kz*Ez = 0
+        # tilde_Ez = -(kx*tilde_Ex + ky*tilde_Ey) / kz
+        # Note: avoid division by zero for kz
+        kz_safe = bd.where(kz == 0, 1e-12, kz)
+        tilde_Ez = -(kx * tilde_Ex + ky * tilde_Ey) / kz_safe
+
+        # Inverse Fourier transform to get the spatial fields
+        self.Ex = bd.fft.ifft2(bd.fft.ifftshift(tilde_Ex))
+        self.Ey = bd.fft.ifft2(bd.fft.ifftshift(tilde_Ey))
+        self.Ez = bd.fft.ifft2(bd.fft.ifftshift(tilde_Ez))
+
+    def get_intensity(self):
+        """
+        Compute total intensity I = |Ex|^2 + |Ey|^2 + |Ez|^2
+        """
+        return bd.real(self.Ex * bd.conj(self.Ex) + self.Ey * bd.conj(self.Ey) + self.Ez * bd.conj(self.Ez))
+
+    def get_stokes_parameters(self):
+        """
+        Compute the Stokes parameters (S0, S1, S2, S3)
+        """
+        S0 = bd.real(self.Ex * bd.conj(self.Ex) + self.Ey * bd.conj(self.Ey))
+        S1 = bd.real(self.Ex * bd.conj(self.Ex) - self.Ey * bd.conj(self.Ey))
+        S2 = bd.real(self.Ex * bd.conj(self.Ey) + self.Ey * bd.conj(self.Ex))
+        S3 = bd.imag(self.Ex * bd.conj(self.Ey) - self.Ey * bd.conj(self.Ex))
+        return S0, S1, S2, S3
+
+    def get_colors(self):
+        """compute RGB colors of the cross-section profile at the current distance"""
+        I = self.get_intensity()
+        rgb = self.cs.wavelength_to_sRGB(self.λ / nm, 10 * I.ravel()).T.reshape(
+            (self.Ny, self.Nx, 3)
+        )
+        return rgb
+
+    def plot_colors(self, **kwargs):
+        from .visualization import plot_colors
+        plot_colors(self, **kwargs)
+
+    def plot_intensity(self, **kwargs):
+        from .visualization import plot_intensity
+        plot_intensity(self, **kwargs)

--- a/examples/polarization_demo.py
+++ b/examples/polarization_demo.py
@@ -1,0 +1,38 @@
+import diffractsim
+diffractsim.set_backend("CPU")
+from diffractsim import mm, nm, cm, VectorialField, CircularAperture, LinearPolarizer, QuarterWavePlate, HalfWavePlate
+import matplotlib.pyplot as plt
+import numpy as np
+
+# wavelength of the field (Red laser)
+wavelength = 633 * nm
+
+# 1. Setup a horizontally polarized field
+print("Setting up horizontally polarized field...")
+F = VectorialField(wavelength, 10 * mm, 10 * mm, 512, 512, pol_state=[1, 0])
+
+# 2. Add a circular aperture
+F.add(CircularAperture(radius=1.5 * mm))
+
+# 3. Add a Quarter Wave Plate at 45 degrees to convert to Circular Polarization
+print("Applying Quarter Wave Plate at 45 degrees...")
+F.add(QuarterWavePlate(fast_axis_angle=45))
+
+# Verify S3 (circular polarization parameter) is high
+S0, S1, S2, S3 = F.get_stokes_parameters()
+avg_S3 = np.mean(S3[F.Ny//2-10:F.Ny//2+10, F.Nx//2-10:F.Nx//2+10])
+print(f"Average S3 in center (should be ~S0 for circular): {avg_S3}")
+
+# 4. Propagate
+print("Propagating...")
+F.propagate(50 * cm)
+
+# 5. Add a vertical polarizer to see if we can filter components
+print("Applying vertical polarizer...")
+F.add(LinearPolarizer(angle=90))
+
+# 6. Final propagation to screen
+F.propagate(50 * cm)
+
+print("Vectorial simulation with polarization elements finished successfully.")
+print(f"Final intensity in center: {np.max(F.get_intensity())}")

--- a/examples/vectorial_polarizer.py
+++ b/examples/vectorial_polarizer.py
@@ -1,0 +1,27 @@
+import diffractsim
+diffractsim.set_backend("CPU") # Use CPU for compatibility in this example
+from diffractsim import mm, nm, cm, VectorialField, CircularAperture, LinearPolarizer, QuarterWavePlate
+
+# wavelength of the field
+wavelength = 633 * nm
+
+# setup the simulation
+# VectorialField(wavelength, extent_x, extent_y, Nx, Ny, intensity, pol_state)
+# pol_state [1, 1] means 45 degree linear polarization
+F = VectorialField(wavelength, 10 * mm, 10 * mm, 512, 512, pol_state=[1, 1])
+
+# add a circular aperture
+F.add(CircularAperture(radius=1.5 * mm))
+
+# add a horizontal polarizer (0 degrees)
+F.add(LinearPolarizer(angle=0))
+
+# propagate the field to 1 meter
+F.propagate(100 * cm)
+
+# plot the result
+# Since this is a head-less environment, we might not see the plot, 
+# but we can save it if needed or just verify it runs.
+# F.plot_colors(saveas = "vectorial_polarizer.png")
+print("Vectorial simulation finished successfully.")
+print(f"Final z: {F.z/cm} cm")


### PR DESCRIPTION
This PR adds a new `VectorialField` class to `diffractsim`, allowing for the simulation of physical optics phenomena that account for light polarization.

### Key Changes:
- **`VectorialField` class**: Implements the vectorial electric field (Ex, Ey, Ez) and its propagation using the Angular Spectrum Method. Ez is correctly derived from Gauss's Law in the Fourier domain.
- **Specialized Optical Elements**: Added `LinearPolarizer` and `Waveplate` (including `HalfWavePlate` and `QuarterWavePlate`) with Jones matrix implementations for vectorial field interaction.
- **Stokes Parameters**: Added `get_stokes_parameters` method to `VectorialField` for analyzing the polarization state (S0, S1, S2, S3).
- **Integration**: The vectorial model is fully integrated with existing scalar elements (apertures, lenses, etc.), which are applied to each field component independently.
- **Examples**: Included `vectorial_polarizer.py` and `polarization_demo.py` to demonstrate conversion from linear to circular polarization and component filtering.

Fixes rafael-fuente/diffractsim/issues#69.