### PR TITLE
Fix plot_intensity() slice plots to respect square_root option

### DIFF
--- a/diffractsim/visualization/plot_intensity.py
+++ b/diffractsim/visualization/plot_intensity.py
@@ -118,7 +118,10 @@ def plot_intensity(self, I, square_root = False, figsize=(7, 6),
             x = self.x
             y = self.y
 
-        ax_slice.plot(x/units, I[np.argmin(abs(y-slice_y_pos)),:]**2)
+        if square_root == False:
+            ax_slice.plot(x/units, I[np.argmin(abs(y-slice_y_pos)),:])
+        else:
+            ax_slice.plot(x/units, I[np.argmin(abs(y-slice_y_pos)),:]**2)
         ax_slice.set_ylabel(r'Intensity $\left[W / m^2 \right]$')
 
         if grid == True:
@@ -151,7 +154,10 @@ def plot_intensity(self, I, square_root = False, figsize=(7, 6),
             x = self.x
             y = self.y
 
-        ax_slice.plot(y/units, I[:, np.argmin(abs(x-slice_x_pos))]**2)
+        if square_root == False:
+            ax_slice.plot(y/units, I[:, np.argmin(abs(x-slice_x_pos))])
+        else:
+            ax_slice.plot(y/units, I[:, np.argmin(abs(x-slice_x_pos))]**2)
         ax_slice.set_ylabel(r'Intensity $\left[W / m^2 \right]$')
 
         if grid == True:


### PR DESCRIPTION
Fixes #46

## Problem
When using plot_intensity() with slice_y_pos or slice_x_pos, the square_root scaling was not being respected. The slice plot always showed I**2, which:
- Worked correctly when square_root=True (I = sqrt(intensity), I**2 = intensity)
- Was incorrect when square_root=False (I = intensity, I**2 = intensity^2)

## Solution
The fix checks the square_root parameter and only squares I when square_root=True:
- When square_root=False: plot I directly (intensity values)
- When square_root=True: plot I**2 to convert sqrt(intensity) back to intensity

This ensures the y-axis label Intensity [W/m^2] is always accurate.

## Changes
Modified diffractsim/visualization/plot_intensity.py:
- Fixed slice_y_pos plotting logic
- Fixed slice_x_pos plotting logic

Total lines changed: 8 insertions, 2 deletions