### PR TITLE
feat: Add vectorial EM field support for polarization optics (fixes #69)

### DIFF
--- a/diffractsim/diffractive_elements/jones_element.py
+++ b/diffractsim/diffractive_elements/jones_element.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+class JonesElement:
+    def __init__(self, J):
+        self.J = np.asarray(J, dtype=complex)
+        if self.J.shape != (2, 2):
+            raise ValueError('J must be 2x2')
+
+    def get_E_components(self, Ex, Ey, xx, yy, lam):
+        shape = Ex.shape
+        v = np.vstack([np.asarray(Ex).reshape(-1), np.asarray(Ey).reshape(-1)])
+        v2 = self.J @ v
+        return v2[0].reshape(shape), v2[1].reshape(shape)

--- a/diffractsim/light_sources/gaussian_beam.py
+++ b/diffractsim/light_sources/gaussian_beam.py
@@ -3,17 +3,22 @@ from ..util.backend_functions import backend as bd
 from .light_source import LightSource
 
 class GaussianBeam(LightSource):
-    def __init__(self, w0):
-        """
-        Creates a Gaussian beam with waist radius equal to w0
-        """
+    def __init__(self, w0, Ex_amplitude=1.0, Ey_amplitude=0.0, phase_diff=0.0):
         global bd
         from ..util.backend_functions import backend as bd
-
         self.w0 = w0
+        self.Ex_amplitude = Ex_amplitude
+        self.Ey_amplitude = Ey_amplitude
+        self.phase_diff = phase_diff
 
-    def get_E(self, E, xx, yy, λ):
-
-        r2 = xx**2 + yy**2 
+    def get_E(self, E, xx, yy, lam):
+        r2 = xx**2 + yy**2
         E = E*bd.exp(-r2/(self.w0**2))
         return E
+
+    def get_E_components(self, Ex, Ey, xx, yy, lam):
+        Ex_mod = self.get_E(Ex, xx, yy, lam)
+        Ey_mod = self.get_E(Ey, xx, yy, lam)
+        Ex_out = self.Ex_amplitude * Ex_mod
+        Ey_out = self.Ey_amplitude * bd.exp(1j * self.phase_diff) * Ey_mod
+        return Ex_out, Ey_out

--- a/diffractsim/light_sources/plane_wave.py
+++ b/diffractsim/light_sources/plane_wave.py
@@ -3,13 +3,19 @@ from ..util.backend_functions import backend as bd
 from .light_source import LightSource
 
 class PlaneWave(LightSource):
-    def __init__(self):
-        """
-        Creates a Gaussian beam with waist radius equal to w0
-        """
+    def __init__(self, Ex_amplitude=1.0, Ey_amplitude=0.0, phase_diff=0.0):
         global bd
         from ..util.backend_functions import backend as bd
+        self.Ex_amplitude = Ex_amplitude
+        self.Ey_amplitude = Ey_amplitude
+        self.phase_diff = phase_diff
 
-    def get_E(self, E, xx, yy, λ):
-        
+    def get_E(self, E, xx, yy, lam):
         return bd.ones_like(xx) * E
+
+    def get_E_components(self, Ex, Ey, xx, yy, lam):
+        Ex_mod = self.get_E(Ex, xx, yy, lam)
+        Ey_mod = self.get_E(Ey, xx, yy, lam)
+        Ex_out = self.Ex_amplitude * Ex_mod
+        Ey_out = self.Ey_amplitude * bd.exp(1j * self.phase_diff) * Ey_mod
+        return Ex_out, Ey_out

--- a/diffractsim/monochromatic_simulator.py
+++ b/diffractsim/monochromatic_simulator.py
@@ -19,7 +19,7 @@ All rights reserved.
 
 
 class MonochromaticField:
-    def __init__(self,  wavelength, extent_x, extent_y, Nx, Ny, intensity = 0.1 * W / (m**2)):
+    def __init__(self, wavelength, extent_x, extent_y, Nx, Ny, intensity = 0.1 * W / (m**2), vectorial=False):
         """
         Initializes the field, representing the cross-section profile of a plane wave
 
@@ -49,14 +49,27 @@ class MonochromaticField:
 
         self.Nx = Nx
         self.Ny = Ny
-        self.E = bd.ones((self.Ny, self.Nx)) * bd.sqrt(intensity)
+        self.vectorial = vectorial
+        if vectorial:
+            self.Ex = bd.ones((self.Ny, self.Nx)) * bd.sqrt(intensity / 2)
+            self.Ey = bd.ones((self.Ny, self.Nx)) * bd.sqrt(intensity / 2)
+            self.E = None
+        else:
+            self.E = bd.ones((self.Ny, self.Nx)) * bd.sqrt(intensity)
+            self.Ex = None
+            self.Ey = None
         self.λ = wavelength
         self.z = 0
         self.cs = cf.ColourSystem(clip_method = 0)
         
     def add(self, optical_element):
-
-        self.E = optical_element.get_E(self.E, self.xx, self.yy, self.λ)
+        if not self.vectorial:
+            self.E = optical_element.get_E(self.E, self.xx, self.yy, self.λ)
+        elif hasattr(optical_element, 'get_E_components'):
+            self.Ex, self.Ey = optical_element.get_E_components(self.Ex, self.Ey, self.xx, self.yy, self.λ)
+        else:
+            self.Ex = optical_element.get_E(self.Ex, self.xx, self.yy, self.λ)
+            self.Ey = optical_element.get_E(self.Ey, self.xx, self.yy, self.λ)
 
 
     def propagate(self, z, scale_factor = 1):
@@ -66,7 +79,11 @@ class MonochromaticField:
         """
 
         self.z += z
-        self.E = angular_spectrum_method(self, self.E, z, self.λ, scale_factor = scale_factor)
+        if self.vectorial:
+            self.Ex = angular_spectrum_method(self, self.Ex, z, self.λ, scale_factor = scale_factor)
+            self.Ey = angular_spectrum_method(self, self.Ey, z, self.λ, scale_factor = scale_factor)
+        else:
+            self.E = angular_spectrum_method(self, self.E, z, self.λ, scale_factor = scale_factor)
 
 
     def scale_propagate(self, z, scale_factor):
@@ -257,7 +274,10 @@ class MonochromaticField:
         """compute RGB colors of the cross-section profile at the current distance"""
 
         # compute Field Intensity
-        I = bd.real(self.E * bd.conjugate(self.E))  
+        if self.vectorial:
+            I = bd.real(self.Ex * bd.conjugate(self.Ex) + self.Ey * bd.conjugate(self.Ey))
+        else:
+            I = bd.real(self.E * bd.conjugate(self.E))  
 
         rgb = self.cs.wavelength_to_sRGB(self.λ / nm, 10 * I.ravel()).T.reshape(
             (self.Ny, self.Nx, 3)
@@ -274,6 +294,8 @@ class MonochromaticField:
     def get_intensity(self):
         """compute field intensity of the cross-section profile at the current distance"""
 
+        if self.vectorial:
+            return bd.real(self.Ex * bd.conjugate(self.Ex) + self.Ey * bd.conjugate(self.Ey))
         return bd.real(self.E * bd.conjugate(self.E))  
 
 

--- a/tests/test_vectorial_polarization.py
+++ b/tests/test_vectorial_polarization.py
@@ -1,0 +1,38 @@
+import numpy as np
+from diffractsim.monochromatic_simulator import MonochromaticField
+from diffractsim.light_sources.plane_wave import PlaneWave
+from diffractsim.diffractive_elements.jones_element import JonesElement
+
+def _make_field(vectorial=True, intensity=1.0):
+    return MonochromaticField(
+        wavelength=532e-9, extent_x=32e-6, extent_y=32e-6,
+        Nx=32, Ny=32, intensity=intensity, vectorial=vectorial)
+
+def test_linear_polarizer_extinction():
+    F = _make_field(vectorial=True, intensity=1.0)
+    src = PlaneWave(Ex_amplitude=1.0, Ey_amplitude=0.0, phase_diff=0.0)
+    F.add(src)
+    J = np.array([[0, 0], [0, 1]], dtype=complex)
+    pol = JonesElement(J)
+    F.add(pol)
+    I = F.get_intensity()
+    assert np.allclose(I, 0.0, atol=1e-12)
+
+def test_qwp_adds_pi_over_2_phase():
+    F = _make_field(vectorial=True, intensity=1.0)
+    src = PlaneWave(Ex_amplitude=1.0, Ey_amplitude=1.0, phase_diff=0.0)
+    F.add(src)
+    J = np.array([[1, 0], [0, 1j]], dtype=complex)
+    qwp = JonesElement(J)
+    F.add(qwp)
+    ex = F.Ex.flat[0]
+    ey = F.Ey.flat[0]
+    assert np.allclose(ey / ex, 1j, atol=1e-12)
+
+def test_scalar_backward_compatibility():
+    Fs = _make_field(vectorial=False)
+    src = PlaneWave()
+    Fs.add(src)
+    I = Fs.get_intensity()
+    assert I.shape == (Fs.Ny, Fs.Nx)
+    assert np.isfinite(I).all()


### PR DESCRIPTION
- Add vectorial=False parameter to MonochromaticField for backward compatibility
- Implement Ex/Ey field component tracking for Jones matrix calculus
- Add JonesElement class for polarization optical elements
- Add polarization attribute to PlaneWave and GaussianBeam sources
- Modify propagate() to handle vector field components separately
- Update intensity calculation for vectorial mode: I = |Ex|^2 + |Ey|^2
- Add comprehensive test suite for vectorial polarization

Tests: Linear polarizer extinction, QWP phase shift, scalar backward compatibility